### PR TITLE
chore: add lint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 - Optional: Create an `eternaltwin.local.toml` config file for Eternaltwin. You don't need it to start LaBrute, but it may be useful for more advanced usage. (An example is provided in the [eternaltwin.local.toml.sample](eternaltwin.local.toml.sample) file)
 
-- Install dependencies: `yarn install` (This should also setup your database from the `schema.prisma` file and the migrations)
+- Install dependencies: `yarn install` (This should also setup your database from the `schema.prisma` file and the migrations). After installation, run `yarn lint` to ensure code quality
 
 - Make sure to initialize your etwin database by running `yarn eternaltwin db sync`
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "db:seed": "cd ./server && yarn db:seed",
     "db:reset": "cd ./server && yarn db:reset",
     "postinstall": "bash ./scripts/postInstall.sh",
+    "lint": "eslint .",
     "studio": "cd ./server && yarn studio",
     "audit": "yarn npm audit --recursive --all --environment production",
     "add:client": "yarn workspace @labrute/client add",


### PR DESCRIPTION
## Summary
- add root `lint` script to run ESLint
- document `yarn lint` after `yarn install`

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5eb561e88320b19fc7bb6fd4949a